### PR TITLE
build: :fire: remove deprecated qs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     magrittr,
     mice,
     ps,
-    qs (>= 0.26.1),
     qs2,
     readr,
     remotes,


### PR DESCRIPTION
The qs package is deprecated and replaced by qs2. So this removes qs from the dependency. 

Closes #30. I think also closes #29 